### PR TITLE
Bugfix: path to binary in the CentOs service unit.

### DIFF
--- a/server/packaging/rpm/SOURCES/stackable-monitoring-operator-server-VERSION/usr/lib/systemd/system/stackable-monitoring-operator-server.service
+++ b/server/packaging/rpm/SOURCES/stackable-monitoring-operator-server-VERSION/usr/lib/systemd/system/stackable-monitoring-operator-server.service
@@ -4,7 +4,7 @@ Before=
 After=network.target
 [Service]
 User=root
-ExecStart=/opt/stackable/stackable-monitoring-operator-server/stackable-monitoring-operator-server
+ExecStart=/opt/stackable/monitoring-operator/stackable-monitoring-operator-server
 Restart=on-abort
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
The path to the operator binary must be the same with asset configured in Cargo.toml