### PR TITLE
Feature/collect node metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,10 +81,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -235,6 +268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +384,12 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fnv"
@@ -469,6 +517,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +534,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "handlebars"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259c65b04c7f45d8cb793c29dae7e4ed0022a70779f33bc8957950b33fc700d7"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -816,6 +887,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "openssl"
 version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1069,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
 ]
 
 [[package]]
@@ -1087,6 +1204,12 @@ dependencies = [
  "serde_yaml",
  "thiserror",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1425,6 +1548,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,6 +1655,7 @@ version = "0.1.0-nightly"
 dependencies = [
  "async-trait",
  "futures",
+ "handlebars",
  "k8s-openapi",
  "kube",
  "product-config",
@@ -1902,6 +2038,12 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "stackable-monitoring-crd",
  "stackable-operator",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8152fba26129a09bf30179092753b399760a305a218b8bc558f9a2087b5c1d70"
+checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
 dependencies = [
  "base64",
  "bytes",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b767df01404bb99fb75ac2ceded28ce34c30fdcffbb4346e2c44d30756bfba"
+checksum = "ffbce0d890efc42abb31e974419e25a643a97ab7c6b3b9498bda686d10b55f8d"
 dependencies = [
  "form_urlencoded",
  "http",
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d0e5489859d9430689f64e69cacc9bf8cb68556f436c73a6a308d4e256b7a0"
+checksum = "95a28be5ca4f233b5dd872f426fdc75d6765c34576b590c44564982c05fdb400"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -768,21 +768,24 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8358421de932e06d0521700fc8ecfc7058c95509e0770d2da88be78cd737c07"
+checksum = "a4f034d330a0849e1603e285389e3f0ed93b9a86017d46e851c9e49e6d0b99e2"
 dependencies = [
  "dashmap",
  "derivative",
  "futures",
+ "json-patch",
  "k8s-openapi",
  "kube",
  "pin-project 1.0.7",
  "serde",
+ "serde_json",
  "smallvec",
  "snafu",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1545,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#aef74f8a0065a2aeab94a10f664e65cbd11306af"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#4394131b2c1326129b97a1b8b97d24dc85c30f70"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1774,6 +1777,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
 dependencies = [
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,18 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.12.4",
+ "darling_macro 0.12.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core 0.13.0",
+ "darling_macro 0.13.0",
 ]
 
 [[package]]
@@ -236,12 +246,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
- "darling_core",
+ "darling_core 0.12.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core 0.13.0",
  "quote",
  "syn",
 ]
@@ -830,7 +865,7 @@ version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a28be5ca4f233b5dd872f426fdc75d6765c34576b590c44564982c05fdb400"
 dependencies = [
- "darling",
+ "darling 0.12.4",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1536,6 +1571,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with_macros"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
+dependencies = [
+ "darling 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +1709,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serde_with_macros",
  "serde_yaml",
  "stackable-monitoring-crd",
  "stackable-operator",

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,9 @@ Currently, this operator uses Prometheus as a metric aggregator per machine. It 
 It uses Kubernetes Service Discovery to scrape pods belonging to its machine/node.
 Pods that should be scraped need to expose a container port called "metrics" as well as an annotation "monitoring.stackable.tec/should_be_scraped=true".
 
+Additionally, a NodeExporter can be configured to collect metrics of the physical machine itself.
+This NodeExporter should be deployed on every machine where these metrics should be exposed.
+
 == Building
 
 This operator is written in Rust.
@@ -28,19 +31,32 @@ The cluster can be configured via a YAML file. This custom resource specifies th
       name: simple
     spec:
       version: 2.28.1
-      servers:
+      nodePods:
         roleGroups:
           default:
             selector:
               matchLabels:
                 kubernetes.io/arch: stackable-linux
-            replicas: 1
             config:
               webUiPort: 10101
               scrapeInterval: 15s
               scrapeTimeout: 5s
               evaluationInterval: 10s
               scheme: http
+      node:
+        roleGroups:
+          default:
+            selector:
+              matchLabels:
+                kubernetes.io/arch: stackable-linux
+            config:
+              metricsPort: 10102
+              nodeExporterArgs:
+                - "--no-collector.wifi"
+                - "--no-collector.hwmon"
+                - "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)"
+                - "--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$"
+                - "--collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$"
 
 === Structure
 
@@ -75,7 +91,7 @@ There are three levels of configuration:
 === Role & RoleGroup options
 We summarize Role and RoleGroup options. They are the same options for Role and RoleGroup.
 
-==== Server
+==== NodePods
 [cols="1,1,1,1,1"]
 |===
 |Name
@@ -113,6 +129,28 @@ We summarize Role and RoleGroup options. They are the same options for Role and 
 |Configures the protocol scheme used for requests.
 |schema
 |prometheus.yaml
+|===
+
+==== Node
+[cols="1,1,1,1,1"]
+|===
+|Name
+|Type
+|Description
+|Related Prometheus/Victoria properties
+|Location
+
+|metricsPort
+|integer
+|Start the Prometheus Node Exporter on a different port (default 9100).
+|--web.listen-address
+|cli
+
+|nodeExporterArgs
+|Array[string]
+|Configuration parameters on what and how to scrape node metrics.
+|
+|cli
 |===
 
 The docs can be found in the `docs` subdirectory, and they are published together with docs for all other Stackable products at https://docs.stackable.tech.

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -11,7 +11,7 @@ product-config = { git = "https://github.com/stackabletech/product-config.git", 
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 
 k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
-kube = { version = "0.57", default-features = false, features = ["derive", "jsonpatch"] }
+kube = { version = "0.58", default-features = false, features = ["derive", "jsonpatch"] }
 schemars = "0.8"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -43,7 +43,11 @@ pub struct MonitoringClusterSpec {
 }
 
 impl MonitoringClusterSpec {
-    pub fn node_exporter_metrics_port(&self, group: &str) -> Option<u16> {
+    /// Extract the metrics_port for a given role_group and node_exporter role (MonitoringRole::Node).
+    ///
+    /// # Arguments
+    /// * `role_group` - The role_group where to search for the metrics_port.
+    pub fn node_exporter_metrics_port(&self, role_group: &str) -> Option<u16> {
         if let Some(Role { role_groups, .. }) = &self.node {
             if let Some(RoleGroup {
                 config:
@@ -51,7 +55,7 @@ impl MonitoringClusterSpec {
                         config: Some(conf), ..
                     }),
                 ..
-            }) = role_groups.get(group)
+            }) = role_groups.get(role_group)
             {
                 return conf.metrics_port;
             }
@@ -59,6 +63,10 @@ impl MonitoringClusterSpec {
         None
     }
 
+    /// Extract the node_exporter_args for a given role_group and node_exporter role (MonitoringRole::Node).
+    ///
+    /// # Arguments
+    /// * `role_group` - The role_group where to search for the metrics_port.
     pub fn node_exporter_args(&self, group: &str) -> Vec<String> {
         if let Some(Role { role_groups, .. }) = &self.node {
             if let Some(RoleGroup {

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -25,7 +25,7 @@ properties:
       defaultValues:
         - value: "9090"
       roles:
-        - name: "pod"
+        - name: "nodepods"
           required: true
         - name: "cluster"
           required: true
@@ -44,7 +44,7 @@ properties:
       defaultValues:
         - value: "10s"
       roles:
-        - name: "pod"
+        - name: "nodepods"
           required: false
         - name: "cluster"
           required: false
@@ -63,7 +63,7 @@ properties:
       defaultValues:
         - value: "10s"
       roles:
-        - name: "pod"
+        - name: "nodepods"
           required: false
         - name: "cluster"
           required: false
@@ -82,7 +82,7 @@ properties:
       defaultValues:
         - value: "10s"
       roles:
-        - name: "pod"
+        - name: "nodepods"
           required: false
         - name: "cluster"
           required: false
@@ -103,16 +103,16 @@ properties:
         - http
         - https
       roles:
-        - name: "pod"
+        - name: "nodepods"
           required: false
         - name: "cluster"
           required: false
       asOfVersion: "0.0.0"
       description: "Configures the protocol scheme used for requests."
 
-  - property: &metricsPort
+  - property: &nodeMetricsPort
       propertyNames:
-        - name: "metricsPort"
+        - name: "nodeMetricsPort"
           kind:
             type: "cli"
       datatype:

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -25,7 +25,9 @@ properties:
       defaultValues:
         - value: "9090"
       roles:
-        - name: "server"
+        - name: "pod"
+          required: true
+        - name: "cluster"
           required: true
       asOfVersion: "0.0.0"
       description: "The port for the WebUi."
@@ -42,7 +44,9 @@ properties:
       defaultValues:
         - value: "10s"
       roles:
-        - name: "server"
+        - name: "pod"
+          required: false
+        - name: "cluster"
           required: false
       asOfVersion: "0.0.0"
       description: "How frequently to scrape targets from this job."
@@ -59,7 +63,9 @@ properties:
       defaultValues:
         - value: "10s"
       roles:
-        - name: "server"
+        - name: "pod"
+          required: false
+        - name: "cluster"
           required: false
       asOfVersion: "0.0.0"
       description: "How long until a scrape request times out."
@@ -76,7 +82,9 @@ properties:
       defaultValues:
         - value: "10s"
       roles:
-        - name: "server"
+        - name: "pod"
+          required: false
+        - name: "cluster"
           required: false
       asOfVersion: "0.0.0"
       description: "How frequently to evaluate rules."
@@ -95,7 +103,27 @@ properties:
         - http
         - https
       roles:
-        - name: "server"
+        - name: "pod"
+          required: false
+        - name: "cluster"
           required: false
       asOfVersion: "0.0.0"
       description: "Configures the protocol scheme used for requests."
+
+  - property: &metricsPort
+      propertyNames:
+        - name: "metricsPort"
+          kind:
+            type: "cli"
+      datatype:
+        type: "integer"
+        unit: *unitPort
+        min: "1024"
+        max: "65535"
+      defaultValues:
+        - value: "9100"
+      roles:
+        - name: "node"
+          required: true
+      asOfVersion: "0.0.0"
+      description: "The node-exporter metrics port."

--- a/deploy/crd/monitoringcluster.crd.yaml
+++ b/deploy/crd/monitoringcluster.crd.yaml
@@ -20,7 +20,229 @@ spec:
           properties:
             spec:
               properties:
-                servers:
+                cluster:
+                  properties:
+                    cliOverrides:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    config:
+                      nullable: true
+                      properties:
+                        evaluationInterval:
+                          nullable: true
+                          type: string
+                        scheme:
+                          nullable: true
+                          type: string
+                        scrapeInterval:
+                          nullable: true
+                          type: string
+                        scrapeTimeout:
+                          nullable: true
+                          type: string
+                        webUiPort:
+                          format: uint16
+                          minimum: 0.0
+                          nullable: true
+                          type: integer
+                      type: object
+                    configOverrides:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      nullable: true
+                      type: object
+                    envOverrides:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    roleGroups:
+                      additionalProperties:
+                        properties:
+                          cliOverrides:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          config:
+                            nullable: true
+                            properties:
+                              evaluationInterval:
+                                nullable: true
+                                type: string
+                              scheme:
+                                nullable: true
+                                type: string
+                              scrapeInterval:
+                                nullable: true
+                                type: string
+                              scrapeTimeout:
+                                nullable: true
+                                type: string
+                              webUiPort:
+                                format: uint16
+                                minimum: 0.0
+                                nullable: true
+                                type: integer
+                            type: object
+                          configOverrides:
+                            additionalProperties:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            nullable: true
+                            type: object
+                          envOverrides:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          replicas:
+                            format: uint16
+                            minimum: 0.0
+                            nullable: true
+                            type: integer
+                          selector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                      type: string
+                                    values:
+                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                type: object
+                            type: object
+                        required:
+                          - selector
+                        type: object
+                      type: object
+                  required:
+                    - roleGroups
+                  type: object
+                node:
+                  properties:
+                    cliOverrides:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    config:
+                      nullable: true
+                      properties:
+                        metricsPort:
+                          format: uint16
+                          minimum: 0.0
+                          nullable: true
+                          type: integer
+                      type: object
+                    configOverrides:
+                      additionalProperties:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      nullable: true
+                      type: object
+                    envOverrides:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    roleGroups:
+                      additionalProperties:
+                        properties:
+                          cliOverrides:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          config:
+                            nullable: true
+                            properties:
+                              metricsPort:
+                                format: uint16
+                                minimum: 0.0
+                                nullable: true
+                                type: integer
+                            type: object
+                          configOverrides:
+                            additionalProperties:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            nullable: true
+                            type: object
+                          envOverrides:
+                            additionalProperties:
+                              type: string
+                            nullable: true
+                            type: object
+                          replicas:
+                            format: uint16
+                            minimum: 0.0
+                            nullable: true
+                            type: integer
+                          selector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                      type: string
+                                    values:
+                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                type: object
+                            type: object
+                        required:
+                          - selector
+                        type: object
+                      type: object
+                  required:
+                    - roleGroups
+                  type: object
+                pod:
                   properties:
                     cliOverrides:
                       additionalProperties:
@@ -148,7 +370,9 @@ spec:
                     - 2.28.1
                   type: string
               required:
-                - servers
+                - cluster
+                - node
+                - pod
                 - version
               type: object
             status:

--- a/deploy/crd/monitoringcluster.crd.yaml
+++ b/deploy/crd/monitoringcluster.crd.yaml
@@ -20,7 +20,8 @@ spec:
           properties:
             spec:
               properties:
-                cluster:
+                federation:
+                  nullable: true
                   properties:
                     cliOverrides:
                       additionalProperties:
@@ -144,6 +145,7 @@ spec:
                     - roleGroups
                   type: object
                 node:
+                  nullable: true
                   properties:
                     cliOverrides:
                       additionalProperties:
@@ -158,6 +160,12 @@ spec:
                           minimum: 0.0
                           nullable: true
                           type: integer
+                        nodeExporterArgs:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - nodeExporterArgs
                       type: object
                     configOverrides:
                       additionalProperties:
@@ -187,6 +195,12 @@ spec:
                                 minimum: 0.0
                                 nullable: true
                                 type: integer
+                              nodeExporterArgs:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - nodeExporterArgs
                             type: object
                           configOverrides:
                             additionalProperties:
@@ -242,7 +256,7 @@ spec:
                   required:
                     - roleGroups
                   type: object
-                pod:
+                nodePods:
                   properties:
                     cliOverrides:
                       additionalProperties:
@@ -370,9 +384,7 @@ spec:
                     - 2.28.1
                   type: string
               required:
-                - cluster
-                - node
-                - pod
+                - nodePods
                 - version
               type: object
             status:

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,5 @@
 * xref:building.adoc[]
 * xref:installation.adoc[]
+* xref:configuration.adoc[]
+* xref:usage.adoc[]
+

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -1,0 +1,11 @@
+
+=== product-config
+
+*Default value*: `/etc/stackable/monitoring-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+
+This file contains property definitions for the monitoring configuration.

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,0 +1,8 @@
+= Configuration
+
+== Command Line Parameters
+This operator accepts the following command line parameters:
+
+include::commandline_args.adoc[]
+
+

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -1,0 +1,44 @@
+= Usage
+
+After installation, the CRD for this operator must be created:
+
+    kubectl apply -f /etc/stackable/monitoring-operator/crd/monitoringcluster.crd.yaml
+
+To create a single node Apache ZooKeeper (v3.5.8) cluster with Prometheus metrics exposed on port 9505:
+
+
+    cat <<EOF | kubectl apply -f -
+    apiVersion: monitoring.stackable.tech/v1alpha1
+    kind: MonitoringCluster
+    metadata:
+      name: simple
+    spec:
+      version: 2.28.1
+      nodePods:
+        roleGroups:
+          default:
+            selector:
+              matchLabels:
+                kubernetes.io/arch: stackable-linux
+            config:
+              webUiPort: 10101
+              scrapeInterval: 15s
+              scrapeTimeout: 5s
+              evaluationInterval: 10s
+              scheme: http
+      node:
+        roleGroups:
+          default:
+            selector:
+              matchLabels:
+                kubernetes.io/arch: stackable-linux
+            config:
+              metricsPort: 10102
+              nodeExporterArgs:
+                - "--no-collector.wifi"
+                - "--no-collector.hwmon"
+                - "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)"
+                - "--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$"
+                - "--collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$"
+      EOF
+

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -4,8 +4,13 @@ After installation, the CRD for this operator must be created:
 
     kubectl apply -f /etc/stackable/monitoring-operator/crd/monitoringcluster.crd.yaml
 
-To create a single node Apache ZooKeeper (v3.5.8) cluster with Prometheus metrics exposed on port 9505:
+The following example creates a monitoring cluster where a Prometheus and a Node Exporter instance is deployed on each node.
 
+Prometheus is configured using the `nodePods` role to scrape all Pods marked with the label `monitoring.stackable.tech/should_be_scraped` **and** that are running
+on the same machine as Prometheus. Properties defined in the `nodePods.roleGroups.default.config` section are applyed to Prometheus.
+
+The role `node` is used to configure the Node Exporter. Metrics are exposed on port `10102` and the `nodeExporterArgs` are passed on to the `node-exporter` executable
+as command line arguments.
 
     cat <<EOF | kubectl apply -f -
     apiVersion: monitoring.stackable.tech/v1alpha1

--- a/examples/simple-monitoringcluster.yaml
+++ b/examples/simple-monitoringcluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: simple
 spec:
   version: 2.28.1
-  servers:
+  nodePods:
     roleGroups:
       default:
         selector:
@@ -16,6 +16,33 @@ spec:
           scrapeTimeout: 5s
           evaluationInterval: 10s
           scheme: http
+  node:
+    roleGroups:
+      default:
+        selector:
+          matchLabels:
+            kubernetes.io/arch: stackable-linux
+        config:
+          metricsPort: 10102
+          nodeExporterArgs:
+            - "--no-collector.wifi"
+            - "--no-collector.hwmon"
+            - "--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)"
+            - "--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$"
+            - "--collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$"
+#  cluster:
+#    roleGroups:
+#      default:
+#        selector:
+#          matchLabels:
+#            kubernetes.io/arch: stackable-linux
+#        replicas: 1
+#        config:
+#          webUiPort: 10103
+#          scrapeInterval: 15s
+#          scrapeTimeout: 5s
+#          evaluationInterval: 10s
+#          scheme: http
 
 
 

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -18,6 +18,7 @@ k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"]
 kube = { version = "0.58", default-features = false, features = ["jsonpatch"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8"
 strum = "0.21"
 strum_macros = "0.21"
 thiserror = "1.0"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -15,7 +15,7 @@ stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git",
 async-trait = "0.1"
 futures = "0.3"
 k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
-kube = { version = "0.57", default-features = false, features = ["jsonpatch"] }
+kube = { version = "0.58", default-features = false, features = ["jsonpatch"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.21"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -19,6 +19,7 @@ kube = { version = "0.58", default-features = false, features = ["jsonpatch"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
+serde_with_macros = "1.4"
 strum = "0.21"
 strum_macros = "0.21"
 thiserror = "1.0"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -23,6 +23,7 @@ strum = "0.21"
 strum_macros = "0.21"
 thiserror = "1.0"
 tracing = "0.1"
+handlebars = "4.1"
 
 [dev-dependencies]
 rstest = "0.10"

--- a/operator/data/test/nodepods.yaml
+++ b/operator/data/test/nodepods.yaml
@@ -1,0 +1,60 @@
+global:
+  evaluation_interval: 10s
+scrape_configs:
+  - job_name: k8pods
+    scrape_interval: 60s
+    scrape_timeout: 10s
+    scheme: http
+    kubernetes_sd_configs:
+      - role: pod
+        kubeconfig_file: KUBECONFIG
+        namespaces:
+          names:
+            - default
+        selectors:
+          - role: pod
+            field: spec.nodeName=test
+    relabel_configs:
+      # only keep pods that have the \"monitoring.stackable.tech/should_be_scraped = true\" annotation.
+      - source_labels: [__meta_kubernetes_pod_annotation_monitoring_stackable_tech_should_be_scraped]
+        regex: true
+        action: keep
+      # only keep discovered pods with the container_port_name 'metrics'
+      # this avoids to discover other controller_port (e.g. clientPort in ZooKeeper)
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: metrics
+      # do not scrape yourself
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        regex: monitoring
+        action: drop
+      # adapt port to provided pod container port
+      - source_labels: [__address__, __meta_kubernetes_pod_container_port_number]
+        action: replace
+        regex: ([^:]+)(?::\\d+)?;(\\d+)
+        replacement: $1:$2
+        target_label: __address__
+      # use all provided pod labels
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: kubernetes_pod_node_name
+      - source_labels: [__meta_kubernetes_pod_host_ip]
+        action: replace
+        target_label: kubernetes_pod_host_ip
+      - source_labels: [__meta_kubernetes_pod_uid]
+        action: replace
+        target_label: kubernetes_pod_uid
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        action: replace
+        target_label: kubernetes_pod_controller_kind
+      - source_labels: [__meta_kubernetes_pod_controller_name]
+        action: replace
+        target_label: kubernetes_pod_controller_name"

--- a/operator/data/test/nodepods_and_node.yaml
+++ b/operator/data/test/nodepods_and_node.yaml
@@ -1,0 +1,68 @@
+global:
+  evaluation_interval: 10s
+scrape_configs:
+  - job_name: node_exporter
+    scrape_interval: 60s
+    static_config:
+      targets:
+        - localhost:9100
+      scheme: http
+      labels:
+        node_id: "this_server"
+  - job_name: k8pods
+    scrape_interval: 60s
+    scrape_timeout: 10s
+    scheme: http
+    kubernetes_sd_configs:
+      - role: pod
+        kubeconfig_file: KUBECONFIG
+        namespaces:
+          names:
+            - default
+        selectors:
+          - role: pod
+            field: spec.nodeName=test
+    relabel_configs:
+      # only keep pods that have the \"monitoring.stackable.tech/should_be_scraped = true\" annotation.
+      - source_labels: [__meta_kubernetes_pod_annotation_monitoring_stackable_tech_should_be_scraped]
+        regex: true
+        action: keep
+      # only keep discovered pods with the container_port_name 'metrics'
+      # this avoids to discover other controller_port (e.g. clientPort in ZooKeeper)
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: metrics
+      # do not scrape yourself
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        regex: monitoring
+        action: drop
+      # adapt port to provided pod container port
+      - source_labels: [__address__, __meta_kubernetes_pod_container_port_number]
+        action: replace
+        regex: ([^:]+)(?::\\d+)?;(\\d+)
+        replacement: $1:$2
+        target_label: __address__
+      # use all provided pod labels
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: kubernetes_pod_node_name
+      - source_labels: [__meta_kubernetes_pod_host_ip]
+        action: replace
+        target_label: kubernetes_pod_host_ip
+      - source_labels: [__meta_kubernetes_pod_uid]
+        action: replace
+        target_label: kubernetes_pod_uid
+      - source_labels: [__meta_kubernetes_pod_controller_kind]
+        action: replace
+        target_label: kubernetes_pod_controller_kind
+      - source_labels: [__meta_kubernetes_pod_controller_name]
+        action: replace
+        target_label: kubernetes_pod_controller_name"

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -24,8 +24,8 @@ pub enum Error {
     #[error("Invalid Configmap. No name found which is required to query the ConfigMap.")]
     InvalidConfigMap,
 
-    #[error("Pod contains invalid id: {source}")]
-    InvalidId {
+    #[error("Error occurred while paring int: {source}")]
+    ParseIntError {
         #[from]
         source: ParseIntError,
     },

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -3,6 +3,15 @@ use std::num::ParseIntError;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("File not found: {file_name}")]
+    FileNotFound { file_name: String },
+
+    #[error("Could not parse yaml file - {file}: {reason}")]
+    YamlFileNotParsable { file: String, reason: String },
+
+    #[error("Could not parse yaml - {content}: {reason}")]
+    YamlNotParsable { content: String, reason: String },
+
     #[error("Kubernetes reported error: {source}")]
     KubeError {
         #[from]

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -36,7 +36,7 @@ pub enum Error {
     #[error("Invalid Configmap. No name found which is required to query the ConfigMap.")]
     InvalidConfigMap,
 
-    #[error("Error occurred while paring int: {source}")]
+    #[error("Error occurred while parsing int: {source}")]
     ParseIntError {
         #[from]
         source: ParseIntError,

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -3,6 +3,9 @@ use std::num::ParseIntError;
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Cannot generate Prometheus configuration: {reason}")]
+    PrometheusConfigCannotBeSerialized { reason: String },
+
     #[error("File not found: {file_name}")]
     FileNotFound { file_name: String },
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod prometheus;
 
 use crate::error::Error;
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -594,7 +594,6 @@ impl MonitoringState {
                     }
 
                     // extract node_exporter_metrics_port from node -> group -> config
-
                     let node_exporter_metrics_port =
                         self.context.resource.spec.node_exporter_metrics_port(group);
 
@@ -605,8 +604,11 @@ impl MonitoringState {
                         )
                         .with_config(config)
                         .with_node_exporter(node_exporter_metrics_port)
-                        .with_node_exporter_io_labels(&self.context.name(), group)
-                        .with_node_exporter_pod_labels(node_name, &self.context.namespace())
+                        .with_node_exporter_labels(
+                            &self.context.name(),
+                            node_name,
+                            &self.context.namespace(),
+                        )
                         .build(),
                     )?;
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -17,8 +17,7 @@ use product_config::types::PropertyNameKind;
 use product_config::ProductConfigManager;
 use stackable_monitoring_crd::{
     MonitoringCluster, MonitoringClusterSpec, MonitoringClusterStatus, MonitoringVersion, APP_NAME,
-    NODE_METRICS_PORT, PROM_EVALUATION_INTERVAL, PROM_SCHEME, PROM_SCRAPE_INTERVAL,
-    PROM_SCRAPE_TIMEOUT, PROM_WEB_UI_PORT,
+    NODE_METRICS_PORT, PROM_WEB_UI_PORT,
 };
 use stackable_operator::builder::{
     ConfigMapBuilder, ContainerBuilder, ContainerPortBuilder, ObjectMetaBuilder, PodBuilder,
@@ -599,7 +598,7 @@ impl MonitoringState {
                             &self.context.client.default_namespace,
                             node_name,
                         )
-                        .with_config(&config)
+                        .with_config(config)
                         .build(),
                     )?;
 

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -605,6 +605,8 @@ impl MonitoringState {
                         )
                         .with_config(config)
                         .with_node_exporter(node_exporter_metrics_port)
+                        .with_node_exporter_io_labels(&self.context.name(), group)
+                        .with_node_exporter_pod_labels(node_name, &self.context.namespace())
                         .build(),
                     )?;
 

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -283,8 +283,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_nodepod_loads_correctly() {
+    fn test_nodepods_config_loads_correctly() {
         let manager = ConfigManager::from_yaml_file("data/test/nodepods.yaml");
+        assert!(manager.is_ok())
+    }
+
+    #[test]
+    fn test_nodepods_and_node_config_loads_correctly() {
+        let manager = ConfigManager::from_yaml_file("data/test/nodepods_and_node.yaml");
         assert!(manager.is_ok())
     }
 }

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -73,7 +73,6 @@ pub struct BasicAuth {
 }
 
 #[skip_serializing_none]
-#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Authorization {
     /// Sets the authentication type of the request.

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -50,7 +50,7 @@ pub struct ScrapeJob {
     /// Configures the scrape request's TLS settings.
     pub tls_config: Option<TlsConfig>,
     /// List of Kubernetes service discovery configurations.
-    pub kubernetes_sd_configs: Option<KubernetesSdConfig>,
+    pub kubernetes_sd_configs: Option<Vec<KubernetesSdConfig>>,
     /// List of labeled statically configured targets for this job.
     pub static_configs: Option<StaticSdConfig>,
     /// List of target relabel configurations.
@@ -191,7 +191,7 @@ pub struct RelabelConfig {
     /// The source labels select values from existing labels. Their content is concatenated
     /// using the configured separator and matched against the configured regular expression
     /// for the replace, keep, and drop actions.
-    pub source_labels: Option<String>,
+    pub source_labels: Option<Vec<String>>,
     /// Separator placed between concatenated source label values.
     pub separator: Option<String>,
     /// Label to which the resulting value is written in a replace action.
@@ -200,7 +200,7 @@ pub struct RelabelConfig {
     /// Regular expression against which the extracted value is matched.
     pub regex: Option<String>,
     /// Modulus to take of the hash of the source label values.
-    pub modulus: usize,
+    pub modulus: Option<usize>,
     /// Replacement value against which a regex replace is performed if the
     /// regular expression matches. Regex capture groups are available.
     pub replacement: Option<String>,
@@ -285,9 +285,6 @@ mod tests {
     #[test]
     fn test_nodepod_loads_correctly() {
         let manager = ConfigManager::from_yaml_file("data/test/nodepods.yaml");
-        if let Err(ref e) = manager {
-            println!("{:?}", e)
-        }
         assert!(manager.is_ok())
     }
 }

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -330,7 +330,18 @@ scrape_configs:
         target_label: kubernetes_pod_controller_kind
       - source_labels: [__meta_kubernetes_pod_controller_name]
         action: replace
-        target_label: kubernetes_pod_controller_name";
+        target_label: kubernetes_pod_controller_name
+{{#if with_node_scraper}}
+  - job_name: node
+    scrape_interval: 60s
+    static_config:
+      targets:
+        - localhost:9100
+      scheme: http
+      labels:
+        node_id: this_server
+{{/#if}}
+ ";
 
 impl ConfigManager {
     /// Create a ProductConfig from a YAML file.
@@ -389,6 +400,7 @@ pub struct NodepodsTemplateDataBuilder {
     scrape_configs_k8s_scheme: String,
     scrape_configs_k8s_namespace: String,
     scrape_configs_k8s_selector_node_name: String,
+    with_node_scraper: bool,
 }
 
 impl NodepodsTemplateDataBuilder {
@@ -400,6 +412,7 @@ impl NodepodsTemplateDataBuilder {
             scrape_configs_k8s_scheme: "https".to_string(),
             scrape_configs_k8s_namespace: namespace.to_string(),
             scrape_configs_k8s_selector_node_name: name.to_string(),
+            with_node_scraper: false,
         }
     }
 

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -1,14 +1,14 @@
 use crate::error;
 use handlebars::Handlebars;
 use serde::{Deserialize, Serialize};
+use serde_with_macros::skip_serializing_none;
 use stackable_monitoring_crd::{
     PROM_EVALUATION_INTERVAL, PROM_SCHEME, PROM_SCRAPE_INTERVAL, PROM_SCRAPE_TIMEOUT,
-    PROM_WEB_UI_PORT,
 };
-
 use std::collections::{BTreeMap, HashMap};
 use std::str::FromStr;
 use std::{fs, str};
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     /// The global configuration specifies parameters that are valid in all other configuration
@@ -18,6 +18,7 @@ pub struct Config {
     pub scrape_configs: Vec<ScrapeJob>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Global {
     /// How frequently to scrape targets from this job.
@@ -30,6 +31,7 @@ pub struct Global {
     pub scrape_configs: Option<Vec<ScrapeJob>>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ScrapeJob {
     /// The job name assigned to scraped metrics by default.
@@ -62,6 +64,7 @@ pub struct ScrapeJob {
     pub relabel_configs: Option<Vec<RelabelConfig>>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BasicAuth {
     pub username: String,
@@ -69,6 +72,8 @@ pub struct BasicAuth {
     pub password_file: Option<String>,
 }
 
+#[skip_serializing_none]
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Authorization {
     /// Sets the authentication type of the request.
@@ -82,6 +87,7 @@ pub struct Authorization {
     pub credentials_file: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OAuth2 {
     pub client_id: String,
@@ -97,6 +103,7 @@ pub struct OAuth2 {
     pub endpoint_params: Option<HashMap<String, Option<String>>>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TlsConfig {
     /// CA certificate to validate API server certificate with.
@@ -111,6 +118,7 @@ pub struct TlsConfig {
     pub insecure_skip_verify: Option<bool>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct KubernetesSdConfig {
     /// The API server addresses. If left empty, Prometheus is assumed to run inside
@@ -160,6 +168,7 @@ pub struct Namespace {
     pub names: Vec<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Selector {
     pub role: KubernetesSdConfigRole,
@@ -183,6 +192,7 @@ impl Default for KubernetesSdConfigRole {
     }
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StaticSdConfig {
     /// The targets specified by the static config.
@@ -191,6 +201,7 @@ pub struct StaticSdConfig {
     pub labels: Option<HashMap<String, String>>,
 }
 
+#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RelabelConfig {
     /// The source labels select values from existing labels. Their content is concatenated
@@ -450,5 +461,14 @@ mod tests {
                 .as_str(),
             "spec.nodeName=localhost"
         )
+    }
+    #[test]
+    fn test_serialize() {
+        let manager = ConfigManager::from_nodepods_template(
+            &NodepodsTemplateDataBuilder::new_with_namespace_and_node_name("default", "localhost"),
+        )
+        .unwrap();
+        let yaml = manager.serialize();
+        assert!(yaml.is_ok())
     }
 }

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -564,7 +564,7 @@ mod tests {
     #[test]
     fn test_nodepods_and_node_template() {
         let manager = ConfigManager::from_nodepods_template(
-            &NodepodsTemplateDataBuilder::new_with_namespace_and_node_name("default", "localhost")
+            NodepodsTemplateDataBuilder::new_with_namespace_and_node_name("default", "localhost")
                 .with_node_exporter(Some(9111)),
         )
         .unwrap();

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -1,13 +1,16 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
+    /// The global configuration specifies parameters that are valid in all other configuration
+    /// contexts. They also serve as defaults for other configuration sections.
     pub global: Global,
+    /// A list of scrape configurations.
     pub scrape_configs: Vec<ScrapeJob>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Global {
     /// How frequently to scrape targets from this job.
     pub scrape_interval: Option<String>,
@@ -19,7 +22,7 @@ pub struct Global {
     pub scrape_configs: Option<Vec<ScrapeJob>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ScrapeJob {
     /// The job name assigned to scraped metrics by default.
     pub job_name: String,
@@ -51,14 +54,14 @@ pub struct ScrapeJob {
     pub relabel_configs: Option<Vec<RelabelConfig>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BasicAuth {
     pub username: String,
     pub password: Option<String>,
     pub password_file: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Authorization {
     /// Sets the authentication type of the request.
     #[serde(rename = "type")]
@@ -71,7 +74,7 @@ pub struct Authorization {
     pub credentials_file: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OAuth2 {
     pub client_id: String,
     pub client_secret: Option<String>,
@@ -86,7 +89,7 @@ pub struct OAuth2 {
     pub endpoint_params: Option<HashMap<String, Option<String>>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TlsConfig {
     /// CA certificate to validate API server certificate with.
     pub ca_file: Option<String>,
@@ -100,7 +103,7 @@ pub struct TlsConfig {
     pub insecure_skip_verify: Option<bool>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct KubernetesSdConfig {
     /// The API server addresses. If left empty, Prometheus is assumed to run inside
     /// of the cluster and will discover API servers automatically and use the pod's
@@ -144,12 +147,12 @@ pub struct KubernetesSdConfig {
     pub selectors: Option<Vec<Selector>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Namespace {
     pub names: Vec<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Selector {
     pub role: String,
     pub label: Option<String>,
@@ -166,7 +169,13 @@ pub enum KubernetesSdConfigRole {
     Service,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+impl Default for KubernetesSdConfigRole {
+    fn default() -> Self {
+        Self::Pod
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StaticSdConfig {
     /// The targets specified by the static config.
     pub targets: Option<Vec<String>>,
@@ -174,7 +183,7 @@ pub struct StaticSdConfig {
     pub labels: Option<HashMap<String, String>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RelabelConfig {
     /// The source labels select values from existing labels. Their content is concatenated
     /// using the configured separator and matched against the configured regular expression
@@ -217,6 +226,12 @@ pub enum Action {
     LabelDrop,
     /// Match regex against all label names. Any label that does not match will be removed from the set of labels.
     LabelKeep,
+}
+
+impl Default for Action {
+    fn default() -> Self {
+        Self::Replace
+    }
 }
 
 #[cfg(test)]

--- a/operator/src/prometheus.rs
+++ b/operator/src/prometheus.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Config {
+    pub global: Global,
+    pub scrape_configs: Vec<ScrapeJob>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Global {
+    /// How frequently to scrape targets from this job.
+    pub scrape_interval: Option<String>,
+    /// Per-scrape timeout when scraping this job.
+    pub scrape_timeout: Option<String>,
+    /// How frequently to evaluate rules.
+    pub evaluation_interval: Option<String>,
+    /// A list of scrape configurations.
+    pub scrape_configs: Option<Vec<ScrapeJob>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ScrapeJob {
+    /// The job name assigned to scraped metrics by default.
+    pub job_name: String,
+    /// How frequently to scrape targets from this job.
+    pub scrape_interval: Option<String>,
+    /// Per-scrape timeout when scraping this job.
+    pub scrape_timeout: Option<String>,
+    /// The HTTP resource path on which to fetch metrics from targets.
+    pub metrics_path: Option<String>,
+    /// Configures the protocol scheme used for requests.
+    pub scheme: Option<String>,
+    /// Sets the `Authorization` header on every scrape request with the
+    /// configured username and password.
+    /// password and password_file are mutually exclusive.
+    pub basic_auth: Option<BasicAuth>,
+    /// Sets the `Authorization` header on every scrape request with
+    /// the configured credentials.
+    pub authorization: Option<Authorization>,
+    /// Optional OAuth 2.0 configuration.
+    /// Cannot be used at the same time as basic_auth or authorization.
+    pub oauth2: Option<OAuth2>,
+    /// Configures the scrape request's TLS settings.
+    pub tls_config: Option<TlsConfig>,
+    /// List of Kubernetes service discovery configurations.
+    pub kubernetes_sd_configs: Option<KubernetesSdConfig>,
+    /// List of labeled statically configured targets for this job.
+    pub static_configs: Option<StaticSdConfig>,
+    /// List of target relabel configurations.
+    pub relabel_configs: Option<Vec<RelabelConfig>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: Option<String>,
+    pub password_file: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Authorization {
+    /// Sets the authentication type of the request.
+    #[serde(rename = "type")]
+    pub typ: String,
+    /// Sets the credentials of the request. It is mutually exclusive with
+    /// `credentials_file`.
+    pub credentials: Option<String>,
+    /// Sets the credentials of the request with the credentials read from the
+    /// configured file. It is mutually exclusive with `credentials`.
+    pub credentials_file: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OAuth2 {
+    pub client_id: String,
+    pub client_secret: Option<String>,
+    /// Read the client secret from a file.
+    /// It is mutually exclusive with `client_secret`.
+    pub client_secret_file: Option<String>,
+    /// Scopes for the token request.
+    pub scopes: Option<Vec<String>>,
+    /// The URL to fetch the token from.
+    pub token_url: String,
+    /// Optional parameters to append to the token URL.
+    pub endpoint_params: Option<HashMap<String, Option<String>>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TlsConfig {
+    /// CA certificate to validate API server certificate with.
+    pub ca_file: Option<String>,
+    /// Certificate and key files for client cert authentication to the server.
+    pub cert_file: Option<String>,
+    pub key_file: Option<String>,
+    /// ServerName extension to indicate the name of the server.
+    /// https://tools.ietf.org/html/rfc4366#section-3.1
+    pub server_name: Option<String>,
+    /// Disable validation of the server certificate.
+    pub insecure_skip_verify: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct KubernetesSdConfig {
+    /// The API server addresses. If left empty, Prometheus is assumed to run inside
+    /// of the cluster and will discover API servers automatically and use the pod's
+    /// CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.
+    pub api_server: Option<String>,
+    /// The Kubernetes role of entities that should be discovered.
+    /// One of endpoints, service, pod, node, or ingress.
+    pub role: KubernetesSdConfigRole,
+    /// Optional path to a kubeconfig file.
+    /// Note that api_server and kube_config are mutually exclusive.
+    pub kubeconfig_file: Option<String>,
+    /// Optional authentication information used to authenticate to the API server.
+    /// Note that `basic_auth` and `authorization` options are mutually exclusive.
+    /// password and password_file are mutually exclusive.
+    /// Optional HTTP basic authentication information.
+    pub basic_auth: Option<BasicAuth>,
+    /// Optional `Authorization` header configuration.
+    pub authorization: Option<Authorization>,
+    /// Optional OAuth 2.0 configuration.
+    /// Cannot be used at the same time as basic_auth or authorization.
+    pub oauth2: Option<OAuth2>,
+    /// Optional proxy URL.
+    pub proxy_url: Option<String>,
+    /// Configure whether HTTP requests follow HTTP 3xx redirects.
+    pub follow_redirects: Option<bool>,
+    /// TLS configuration.
+    pub tls_config: Option<TlsConfig>,
+    /// Optional namespace discovery. If omitted, all namespaces are used.
+    pub namespaces: Option<Namespace>,
+    /// Optional label and field selectors to limit the discovery process to a subset of available resources.
+    /// See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
+    /// and https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ to learn more about the possible
+    /// filters that can be used. Endpoints role supports pod, service and endpoints selectors, other roles
+    /// only support selectors matching the role itself (e.g. node role can only contain node selectors).
+    /// Note: When making decision about using field/label selector make sure that this
+    /// is the best approach - it will prevent Prometheus from reusing single list/watch
+    /// for all scrape configs. This might result in a bigger load on the Kubernetes API,
+    /// because per each selector combination there will be additional LIST/WATCH. On the other hand,
+    /// if you just want to monitor small subset of pods in large cluster it's recommended to use selectors.
+    /// Decision, if selectors should be used or not depends on the particular situation.
+    pub selectors: Option<Vec<Selector>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Namespace {
+    pub names: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Selector {
+    pub role: String,
+    pub label: Option<String>,
+    pub field: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KubernetesSdConfigRole {
+    Endpoints,
+    Ingress,
+    Node,
+    Pod,
+    Service,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StaticSdConfig {
+    /// The targets specified by the static config.
+    pub targets: Option<Vec<String>>,
+    /// Labels assigned to all metrics scraped from the targets.
+    pub labels: Option<HashMap<String, String>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RelabelConfig {
+    /// The source labels select values from existing labels. Their content is concatenated
+    /// using the configured separator and matched against the configured regular expression
+    /// for the replace, keep, and drop actions.
+    pub source_labels: Option<String>,
+    /// Separator placed between concatenated source label values.
+    pub separator: Option<String>,
+    /// Label to which the resulting value is written in a replace action.
+    /// It is mandatory for replace actions. Regex capture groups are available.
+    pub target_label: Option<String>,
+    /// Regular expression against which the extracted value is matched.
+    pub regex: Option<String>,
+    /// Modulus to take of the hash of the source label values.
+    pub modulus: usize,
+    /// Replacement value against which a regex replace is performed if the
+    /// regular expression matches. Regex capture groups are available.
+    pub replacement: Option<String>,
+    /// Action to perform based on regex matching.
+    pub action: Option<Action>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    /// Drop targets for which regex matches the concatenated source_labels.
+    Drop,
+    /// Set target_label to the modulus of a hash of the concatenated source_labels.
+    HashMod,
+    /// Drop targets for which regex does not match the concatenated source_labels.
+    Keep,
+    /// Match regex against the concatenated source_labels. Then, set target_label to replacement,
+    /// with match group references (${1}, ${2}, ...) in replacement substituted by their value.
+    /// If regex does not match, no replacement takes place.
+    Replace,
+    /// Match regex against all label names. Then copy the values of the matching labels to label
+    /// names given by replacement with match group references (${1}, ${2}, ...) in replacement
+    /// substituted by their value.
+    LabelMap,
+    /// Match regex against all label names. Any label that matches will be removed from the set of labels.
+    LabelDrop,
+    /// Match regex against all label names. Any label that does not match will be removed from the set of labels.
+    LabelKeep,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test() {}
+}


### PR DESCRIPTION
The Monitoring operator now deploys two different roles:
1) (existing) One Prometheus server pod on each node to aggregate pod/jvm/.. metrics
2) (new) One NodeExporter pod on each node to expose metrics from the physical machine (will be scraped via static_sd_configs from the existing Prometheus server on the same node (1). This configuration is optional.